### PR TITLE
feat(event): add gigs

### DIFF
--- a/database/migrations/2026.08.19T20.11.43.backfill-legacy-event-gigs.js
+++ b/database/migrations/2026.08.19T20.11.43.backfill-legacy-event-gigs.js
@@ -20,6 +20,13 @@ const GIG_UID = 'api::gig.gig'
 
 module.exports = {
   async up(knex) {
+    // Custom migrations run before Strapi's content-type schema sync, so on
+    // a genuinely fresh install `events`/`gigs` don't exist yet - and there's
+    // nothing to backfill anyway.
+    if (!(await knex.schema.hasTable('events'))) {
+      return
+    }
+
     const legacyEvents = await knex('events')
       .whereNotNull('date_start')
       .whereNotExists(function () {

--- a/database/migrations/2026.08.19T20.11.43.backfill-legacy-event-gigs.js
+++ b/database/migrations/2026.08.19T20.11.43.backfill-legacy-event-gigs.js
@@ -1,0 +1,80 @@
+'use strict'
+
+// Strapi loads migrations with `require()`, not a TS/ESM loader.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const crypto = require('node:crypto')
+
+// Before the Event->Gig model existed, an `event` row's own dateStart/
+// dateEnd/location/title/description/url/image fields described its one
+// and only performance. The frontend still reads those flat fields as an
+// implicit single gig for any event with no `gigs` (see
+// `transformLegacyEvent` in creal's events page), so this migration is
+// optional for correctness - it only exists to give old events a real
+// `gig` row, e.g. so editors can add a second gig to them later.
+//
+// Only events with a `dateStart` and no gig already linked are backfilled,
+// mirroring the frontend's own legacy/gig-model split exactly.
+
+const EVENT_UID = 'api::event.event'
+const GIG_UID = 'api::gig.gig'
+
+module.exports = {
+  async up(knex) {
+    const legacyEvents = await knex('events')
+      .whereNotNull('date_start')
+      .whereNotExists(function () {
+        this.select('*')
+          .from('gigs_event_lnk')
+          .whereRaw('gigs_event_lnk.event_id = events.id')
+      })
+
+    for (const event of legacyEvents) {
+      const [inserted] = await knex('gigs')
+        .insert({
+          document_id: crypto.randomBytes(12).toString('hex'),
+          title: event.title,
+          description: event.description,
+          date_start: event.date_start,
+          date_end: event.date_end,
+          url: event.url,
+          location: event.location,
+          created_at: event.created_at,
+          updated_at: event.updated_at,
+          published_at: event.published_at,
+          created_by_id: event.created_by_id,
+          updated_by_id: event.updated_by_id,
+          locale: event.locale,
+        })
+        .returning('id')
+      const gigId = inserted.id ?? inserted
+
+      await knex('gigs_event_lnk').insert({
+        gig_id: gigId,
+        event_id: event.id,
+        gig_ord: 1,
+      })
+
+      const eventImages = await knex('files_related_mph').where({
+        related_id: event.id,
+        related_type: EVENT_UID,
+        field: 'image',
+      })
+
+      for (const image of eventImages) {
+        await knex('files_related_mph').insert({
+          file_id: image.file_id,
+          related_id: gigId,
+          related_type: GIG_UID,
+          field: 'image',
+          order: image.order,
+        })
+      }
+    }
+  },
+
+  async down() {
+    throw new Error(
+      'Reverting would delete backfilled gigs indiscriminately - restore from a backup instead.',
+    )
+  },
+}

--- a/database/migrations/2026.08.19T20.11.43.backfill-legacy-event-gigs.js
+++ b/database/migrations/2026.08.19T20.11.43.backfill-legacy-event-gigs.js
@@ -4,19 +4,54 @@
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const crypto = require('node:crypto')
 
-// Before the Event->Gig model existed, an `event` row's own dateStart/
-// dateEnd/location/title/description/url/image fields described its one
-// and only performance. The frontend still reads those flat fields as an
-// implicit single gig for any event with no `gigs` (see
-// `transformLegacyEvent` in creal's events page), so this migration is
-// optional for correctness - it only exists to give old events a real
-// `gig` row, e.g. so editors can add a second gig to them later.
+// Before the Event->Gig model existed, one performance was one `event` row:
+// its own dateStart/dateEnd/location/title/description/url/image fields
+// described it directly, and the frontend rendered them as-is (see
+// `CrEvent.vue` in creal, which still displays an event's own fields
+// whether or not it has gigs). Recurring performances - a festival with
+// several days, a conference happening again next year - were entered as
+// several `event` rows sharing the same title, one carrying the rich
+// details (description/image/url) and the rest bare placeholders for the
+// other times. That's the exact shape the new Gig model was built for:
+// one Event with several Gigs.
 //
-// Only events with a `dateStart` and no gig already linked are backfilled,
-// mirroring the frontend's own legacy/gig-model split exactly.
+// This migration finds those same-titled, closely-dated legacy rows,
+// keeps the richest one as the surviving Event, and turns the rest into
+// that Event's Gigs. Legacy events with no such duplicate are left alone -
+// the frontend already displays a gig-less event correctly from its own
+// fields, so there's nothing to backfill for them.
+//
+// Only events with a `dateStart` and no gig already linked are considered,
+// so events already curated under the new model (or previously processed
+// by this migration) are never touched twice.
 
 const EVENT_UID = 'api::event.event'
 const GIG_UID = 'api::gig.gig'
+const CLUSTER_GAP_MILLISECONDS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+const clusterByProximity = (events) => {
+  const sorted = [...events].sort(
+    (a, b) => new Date(a.date_start) - new Date(b.date_start),
+  )
+
+  const clusters = []
+  let current = [sorted[0]]
+
+  for (let i = 1; i < sorted.length; i++) {
+    const gap =
+      new Date(sorted[i].date_start) - new Date(sorted[i - 1].date_start)
+
+    if (gap <= CLUSTER_GAP_MILLISECONDS) {
+      current.push(sorted[i])
+    } else {
+      clusters.push(current)
+      current = [sorted[i]]
+    }
+  }
+  clusters.push(current)
+
+  return clusters
+}
 
 module.exports = {
   async up(knex) {
@@ -35,53 +70,91 @@ module.exports = {
           .whereRaw('gigs_event_lnk.event_id = events.id')
       })
 
+    const groups = new Map()
     for (const event of legacyEvents) {
-      const [inserted] = await knex('gigs')
-        .insert({
-          document_id: crypto.randomBytes(12).toString('hex'),
-          title: event.title,
-          description: event.description,
-          date_start: event.date_start,
-          date_end: event.date_end,
-          url: event.url,
-          location: event.location,
-          created_at: event.created_at,
-          updated_at: event.updated_at,
-          published_at: event.published_at,
-          created_by_id: event.created_by_id,
-          updated_by_id: event.updated_by_id,
-          locale: event.locale,
-        })
-        .returning('id')
-      const gigId = inserted.id ?? inserted
+      const key = `${event.locale} ${event.title}`
+      if (!groups.has(key)) {
+        groups.set(key, [])
+      }
+      groups.get(key).push(event)
+    }
 
-      await knex('gigs_event_lnk').insert({
-        gig_id: gigId,
-        event_id: event.id,
-        gig_ord: 1,
-      })
+    for (const group of groups.values()) {
+      for (const cluster of clusterByProximity(group)) {
+        if (cluster.length === 1) {
+          continue
+        }
 
-      const eventImages = await knex('files_related_mph').where({
-        related_id: event.id,
-        related_type: EVENT_UID,
-        field: 'image',
-      })
+        const imageCounts = new Map()
+        for (const event of cluster) {
+          const { count } = await knex('files_related_mph')
+            .where({
+              field: 'image',
+              related_id: event.id,
+              related_type: EVENT_UID,
+            })
+            .count({ count: '*' })
+            .first()
+          imageCounts.set(event.id, Number(count))
+        }
 
-      for (const image of eventImages) {
-        await knex('files_related_mph').insert({
-          file_id: image.file_id,
-          related_id: gigId,
-          related_type: GIG_UID,
-          field: 'image',
-          order: image.order,
-        })
+        const richness = (event) =>
+          (event.description ? 2 : 0) +
+          (imageCounts.get(event.id) ? 2 : 0) +
+          (event.url ? 1 : 0)
+
+        const survivor = cluster.reduce((best, event) =>
+          richness(event) > richness(best) ? event : best,
+        )
+
+        let gigOrd = 1
+        for (const event of cluster) {
+          if (event === survivor) {
+            continue
+          }
+
+          const [inserted] = await knex('gigs')
+            .insert({
+              created_at: event.created_at,
+              created_by_id: event.created_by_id,
+              date_end: event.date_end,
+              date_start: event.date_start,
+              description: event.description,
+              document_id: crypto.randomBytes(12).toString('hex'),
+              location: event.location,
+              locale: event.locale,
+              published_at: event.published_at,
+              title: event.title,
+              updated_at: event.updated_at,
+              updated_by_id: event.updated_by_id,
+              url: event.url,
+            })
+            .returning('id')
+          const gigId = inserted.id ?? inserted
+
+          await knex('gigs_event_lnk').insert({
+            event_id: survivor.id,
+            gig_id: gigId,
+            gig_ord: gigOrd++,
+          })
+
+          await knex('files_related_mph')
+            .where({
+              field: 'image',
+              related_id: event.id,
+              related_type: EVENT_UID,
+            })
+            .update({ related_id: gigId, related_type: GIG_UID })
+
+          await knex('events').where({ id: event.id }).delete()
+        }
       }
     }
   },
 
   async down() {
     throw new Error(
-      'Reverting would delete backfilled gigs indiscriminately - restore from a backup instead.',
+      'Reverting would delete backfilled gigs and merged event rows indiscriminately - restore from a backup instead.',
     )
   },
 }

--- a/src/api/gig/content-types/gig/schema.json
+++ b/src/api/gig/content-types/gig/schema.json
@@ -1,11 +1,10 @@
 {
   "kind": "collectionType",
-  "collectionName": "events",
+  "collectionName": "gigs",
   "info": {
-    "singularName": "event",
-    "pluralName": "events",
-    "displayName": "Event",
-    "description": ""
+    "singularName": "gig",
+    "pluralName": "gigs",
+    "displayName": "Gig"
   },
   "options": {
     "draftAndPublish": true
@@ -17,73 +16,73 @@
   },
   "attributes": {
     "title": {
+      "type": "string",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "type": "string",
       "required": true
     },
     "description": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "richtext"
-    },
-    "dateStart": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "datetime",
-      "required": true
-    },
-    "dateEnd": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "datetime"
-    },
-    "url": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": true
-        }
-      },
-      "type": "string"
-    },
-    "image": {
-      "type": "media",
-      "multiple": false,
-      "required": false,
-      "allowedTypes": [
-        "images"
-      ],
+      "type": "blocks",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       }
     },
-    "location": {
+    "dateStart": {
+      "type": "datetime",
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
       },
-      "type": "string"
+      "required": true
     },
-    "gigs": {
+    "dateEnd": {
+      "type": "datetime",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "url": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "image": {
+      "type": "media",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "multiple": false,
+      "allowedTypes": [
+        "files",
+        "images"
+      ]
+    },
+    "location": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "event": {
       "type": "relation",
-      "relation": "oneToMany",
-      "target": "api::gig.gig",
-      "mappedBy": "event"
+      "relation": "manyToOne",
+      "target": "api::event.event",
+      "inversedBy": "gigs"
     }
   }
 }

--- a/src/api/gig/content-types/gig/schema.json
+++ b/src/api/gig/content-types/gig/schema.json
@@ -25,7 +25,7 @@
       "required": true
     },
     "description": {
-      "type": "blocks",
+      "type": "richtext",
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/src/api/gig/content-types/gig/schema.json
+++ b/src/api/gig/content-types/gig/schema.json
@@ -82,7 +82,8 @@
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::event.event",
-      "inversedBy": "gigs"
+      "inversedBy": "gigs",
+      "required": true
     }
   }
 }

--- a/src/api/gig/controllers/gig.ts
+++ b/src/api/gig/controllers/gig.ts
@@ -1,0 +1,7 @@
+/**
+ * gig controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::gig.gig')

--- a/src/api/gig/routes/gig.ts
+++ b/src/api/gig/routes/gig.ts
@@ -1,0 +1,7 @@
+/**
+ * gig router
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreRouter('api::gig.gig')

--- a/src/api/gig/services/gig.ts
+++ b/src/api/gig/services/gig.ts
@@ -1,0 +1,7 @@
+/**
+ * gig service
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreService('api::gig.gig')

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -479,6 +479,7 @@ export interface ApiEventEvent extends Struct.CollectionTypeSchema {
           localized: true
         }
       }>
+    gigs: Schema.Attribute.Relation<'oneToMany', 'api::gig.gig'>
     image: Schema.Attribute.Media<'images'> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
@@ -553,6 +554,79 @@ export interface ApiFaqFaq extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private
+  }
+}
+
+export interface ApiGigGig extends Struct.CollectionTypeSchema {
+  collectionName: 'gigs'
+  info: {
+    displayName: 'Gig'
+    pluralName: 'gigs'
+    singularName: 'gig'
+  }
+  options: {
+    draftAndPublish: true
+  }
+  pluginOptions: {
+    i18n: {
+      localized: true
+    }
+  }
+  attributes: {
+    createdAt: Schema.Attribute.DateTime
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private
+    dateEnd: Schema.Attribute.DateTime &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    dateStart: Schema.Attribute.DateTime &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    description: Schema.Attribute.Blocks &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    event: Schema.Attribute.Relation<'manyToOne', 'api::event.event'>
+    image: Schema.Attribute.Media<'files' | 'images'> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    locale: Schema.Attribute.String
+    localizations: Schema.Attribute.Relation<'oneToMany', 'api::gig.gig'>
+    location: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    publishedAt: Schema.Attribute.DateTime
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    updatedAt: Schema.Attribute.DateTime
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private
+    url: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
   }
 }
 
@@ -1134,6 +1208,7 @@ declare module '@strapi/strapi' {
       'admin::user': AdminUser
       'api::event.event': ApiEventEvent
       'api::faq.faq': ApiFaqFaq
+      'api::gig.gig': ApiGigGig
       'api::testimonial.testimonial': ApiTestimonialTestimonial
       'plugin::content-releases.release': PluginContentReleasesRelease
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -589,7 +589,7 @@ export interface ApiGigGig extends Struct.CollectionTypeSchema {
           localized: true
         }
       }>
-    description: Schema.Attribute.Blocks &
+    description: Schema.Attribute.RichText &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -598,7 +598,8 @@ export interface ApiGigGig extends Struct.CollectionTypeSchema {
           localized: true
         }
       }>
-    event: Schema.Attribute.Relation<'manyToOne', 'api::event.event'>
+    event: Schema.Attribute.Relation<'manyToOne', 'api::event.event'> &
+      Schema.Attribute.Required
     image: Schema.Attribute.Media<'files' | 'images'> &
       Schema.Attribute.SetPluginOptions<{
         i18n: {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -249,6 +249,7 @@ export interface AdminSession extends Struct.CollectionTypeSchema {
     locale: Schema.Attribute.String & Schema.Attribute.Private
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::session'> &
       Schema.Attribute.Private
+    metadata: Schema.Attribute.JSON & Schema.Attribute.Private
     origin: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.Private
@@ -431,6 +432,8 @@ export interface AdminUser extends Struct.CollectionTypeSchema {
     publishedAt: Schema.Attribute.DateTime
     registrationToken: Schema.Attribute.String & Schema.Attribute.Private
     resetPasswordToken: Schema.Attribute.String & Schema.Attribute.Private
+    resetPasswordTokenExpiresAt: Schema.Attribute.DateTime &
+      Schema.Attribute.Private
     roles: Schema.Attribute.Relation<'manyToMany', 'admin::role'> &
       Schema.Attribute.Private
     updatedAt: Schema.Attribute.DateTime
@@ -1196,7 +1199,7 @@ export interface PluginUsersPermissionsUser
 }
 
 declare module '@strapi/strapi' {
-  export module Public {
+  export namespace Public {
     export interface ContentTypeSchemas {
       'admin::api-token': AdminApiToken
       'admin::api-token-permission': AdminApiTokenPermission


### PR DESCRIPTION
This pull request introduces a new `Gig` model to the codebase, establishes a structured relationship between `Event` and `Gig`, and provides a migration to backfill legacy event data into the new model. These changes enable events to have multiple associated gigs, improving flexibility and future extensibility.

**New Gig Model and Relations:**

* Added the `Gig` collection type with fields such as `title`, `description`, `dateStart`, `dateEnd`, `url`, `image`, `location`, and a required relation to `Event`. The model supports localization and draft/publish features.
* Updated the `Event` model to include a one-to-many `gigs` relation, allowing each event to have multiple gigs.

**Data Migration:**

* Added a migration script to backfill legacy events (those with a `dateStart` and no gigs) by creating a corresponding `Gig` record for each, copying over relevant fields and images, and linking them to the event. This ensures data consistency and prepares for future multi-gig events.

**API Layer:**

* Introduced core controller, service, and router files for the new `Gig` model, enabling standard CRUD operations via Strapi's APIs.

See:
- https://github.com/dargmuesli/creal/issues/320