### PR TITLE
feat!: rename underscore to dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/dargmuesli/creal_strapi/actions/workflows/ci.yml/badge.svg)](https://github.com/dargmuesli/creal_strapi/actions/workflows/ci.yml)
+[![CI](https://github.com/dargmuesli/creal-strapi/actions/workflows/ci.yml/badge.svg)](https://github.com/dargmuesli/creal-strapi/actions/workflows/ci.yml)
 
 # cReal's Strapi
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "author": "Jonas Thelemann <e-mail+dargmuesli/creal_strapi@jonas-thelemann.de>",
+  "author": "Jonas Thelemann <e-mail+dargmuesli/creal-strapi@jonas-thelemann.de>",
   "dependencies": {
     "@babel/core": "8.0.1",
     "@babel/runtime": "8.0.0",
@@ -43,7 +43,7 @@
     "node": ">=18.0.0 <=24.19.0"
   },
   "license": "MIT",
-  "name": "creal_strapi",
+  "name": "creal-strapi",
   "private": true,
   "scripts": {
     "build": "strapi build",


### PR DESCRIPTION
This pull request updates the project to use the new naming convention `creal-strapi` instead of `creal_strapi`. The changes ensure consistency in naming across documentation, metadata, and repository links.

**Repository and package naming updates:**

* Updated the CI badge and links in `README.md` to reference the new GitHub repository name `creal-strapi` instead of `creal_strapi`.
* Changed the `author` email and `name` fields in `package.json` to use `creal-strapi` for consistency with the new repository name.